### PR TITLE
[FEAT/#32] 로그인 여부에 따라 홈화면 환영인사 다르게 표시하는 기능 구현

### DIFF
--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -3,11 +3,17 @@ import SearchBar from "./component/SearchBar";
 import IntegratedRanking from "./component/IntegratedRanking";
 import LiveDiscussion from "./component/LiveDiscussion";
 import CommunityRanking from "./component/CommunityRanking";
+import GreetingMessage from "./component/GreetingMessage";
 
 const HomePage = () => {
+  // 여기에 실제 로그인 상태를 확인하는 로직을 추가해야 함
+  // const isLoggedIn = false; 
+  const isLoggedIn = true;
+
   return (
     <div className="bg-[#F8F9FC] w-[390px] mx-auto">
       <Header />
+      <GreetingMessage isLoggedIn={isLoggedIn} />
       <SearchBar />
       <IntegratedRanking />
       <LiveDiscussion />

--- a/src/pages/HomePage/component/GreetingMessage.tsx
+++ b/src/pages/HomePage/component/GreetingMessage.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const GreetingMessage: React.FC<{ isLoggedIn: boolean }> = ({ isLoggedIn }) => {
+    return (
+      <div className="text-[#2E333B] font-pretendard text-[20px] font-bold ml-[24px]">
+        {isLoggedIn ? (
+          <>
+            <span className="block">현주님,</span>
+            <span className="block">
+              오늘의 <span className="text-[#7620E4]">연예</span> 소식을 확인해보세요!
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="block">반가워요,</span>
+            <span className="block">
+              로그인하고 소식을 확인해보세요!
+            </span>
+          </>
+        )}
+      </div>
+    );
+  };
+
+  export default GreetingMessage;

--- a/src/pages/HomePage/component/Header.tsx
+++ b/src/pages/HomePage/component/Header.tsx
@@ -9,7 +9,6 @@ const Header: React.FC = () => {
   // const isLoggedIn = false; 
   const isLoggedIn = true;
 
-
   const handleProfileClick = () => {
     if (isLoggedIn) {
       navigate('/my-page');

--- a/src/pages/HomePage/component/SearchBar.tsx
+++ b/src/pages/HomePage/component/SearchBar.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import ico_search from "../../../assets/images/ico_search.svg";
 import logo from "../../../assets/images/etc/logo.png";
+
 const SearchBar: React.FC = () => {
   return (
     <div className="flex flex-col justify-start">
       <div className="mb-4 flex flex-col items-start">
         <div className="text-[#2E333B] font-pretendard text-[20px] font-bold ml-[24px]">
-          <span className="block">현주님,</span>
-          <span className="block">
-            오늘의 <span className="text-[#7620E4]">연예</span> 소식을 확인해보세요!
-          </span>
         </div>
       </div>
 


### PR DESCRIPTION
-isLoggedIn의 상태에 따라 홈화면의 환영인사를 다르게 보여주기 위해 GreetingMessage 추가

## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요. ( main ❌ / develop ⭕ )
- PR의 제목에도 관련 이슈 번호를 포함시켜 주세요.
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #32 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x]  비 로그인시 홈 화면 다르게 보여주기
- [x] 환영인사 부분 SearchBar 컴포넌트에서 GreetingMessage 컴포넌트로 분리해주기

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
 `const isLoggedIn = false; `
<img width="336" alt="Screenshot 2024-07-29 at 5 58 02 PM" src="https://github.com/user-attachments/assets/183a6133-ce5b-4ff8-b239-91796ffcf9a2">
`  const isLoggedIn = true; `
<img width="346" alt="Screenshot 2024-07-29 at 5 57 44 PM" src="https://github.com/user-attachments/assets/9e5ea027-546c-4103-a8b9-141e2962a7ca">



## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- 기존에는 HomePage/components/SearchBar.tsx에 환영인사가 있었습니다
- 로그인 여부에 따라 다르게 보여주기 위해 GreetingMessage 컴포넌트를 만들었고, 로그인 여부에 따라 다른 메세지가 보여지게 하였습니다.
- 로그인 여부는 HomePage.tsx에 정의되어 있습니다
```tsx
//HomePage.tsx
const HomePage = () => {
  // 여기에 실제 로그인 상태를 확인하는 로직을 추가해야 함
  // const isLoggedIn = false; 
  const isLoggedIn = true;

  return (
    <div className="bg-[#F8F9FC] w-[390px] mx-auto">
      <Header />
      <GreetingMessage isLoggedIn={isLoggedIn} />
      <SearchBar />
      <IntegratedRanking />
      <LiveDiscussion />
      <CommunityRanking />
    </div>
  );
}

```


### Consideration
HomePagecomponents/Header.tsx 컴포넌트에도 로그인 여부에 따라 로그인 or 마이페이지로 다르게 라우팅해주기 위해 IsLoggedIn이 중복되어 정의되어 있습니다
```
  // const isLoggedIn = false; 
const isLoggedIn = true;
```
 이를 HomePage.tsx에서 검사하는 것과 합칠 수 있으면 좋겠습니다.(중복 제거)