### PR TITLE
[FEAT/#28] 회원가입 약관 동의 화면 구현

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import './index.css';
 import HomePage from './pages/HomePage/HomePage';
 import SignUpPage from './pages/SignUpPage/SignUpPage';
 import LoginPage from './pages/LoginPage/LoginPage';
-import SetProfile from './pages/SetProfile/SetProfile';
+// import SetProfile from './pages/SetProfile/SetProfile';
 import ParticipatedDebatesPage from './pages/HistoryPage/ParticipatedDebate';
 import DebatePage from './pages/HistoryPage/Debate';
 import RankingPage from './pages/RankingPage/RankingPage';
@@ -23,7 +23,6 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <Route path="/login" element={<LoginPage />} />
         {/* <Route path="/set-profile" element={<SetProfile />} /> */}
         <Route path="/new-set-profile" element={<NewSetProfile />} />
-
         <Route path="/participated-debates" element={<ParticipatedDebatesPage />} />
         <Route path="/debate" element={<DebatePage />} />
         <Route path="/ranking" element={<RankingPage />} />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import PwdChangePage from './pages/ChangeInfoPage/PwdChangePage';
 import MyPage from './pages/MyPage/MyPage';
 import ProfileEditPage from './pages/ChangeInfoPage/ProfileEditPage';
 import NewSetProfile from './pages/SetProfile/NewSetProfile';
+import AgreementPage from './pages/AgreementPage/AgreementPage';
 ReactDOM.createRoot(document.getElementById('root')!).render(
   // <React.StrictMode>
     <BrowserRouter>
@@ -29,7 +30,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <Route path="/change-password" element={<PwdChangePage />} />
         <Route path="/my-page" element={<MyPage />} />
         <Route path="/profile-edit" element={<ProfileEditPage />} />
-
+        <Route path='/agreement' element={<AgreementPage/>} />
       </Routes>
     </BrowserRouter>
   // </React.StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import './index.css';
 import HomePage from './pages/HomePage/HomePage';
 import SignUpPage from './pages/SignUpPage/SignUpPage';
 import LoginPage from './pages/LoginPage/LoginPage';
-// import SetProfile from './pages/SetProfile/SetProfile';
+//import SetProfile from './pages/SetProfile/SetProfile';
 import ParticipatedDebatesPage from './pages/HistoryPage/ParticipatedDebate';
 import DebatePage from './pages/HistoryPage/Debate';
 import RankingPage from './pages/RankingPage/RankingPage';

--- a/src/pages/AgreementPage/AgreementPage.tsx
+++ b/src/pages/AgreementPage/AgreementPage.tsx
@@ -1,8 +1,85 @@
-import React from "react";
+import React, { useState } from "react";
+import ico_roundcheck_filled from "../../assets/images/24x24/ico_roundcheck_filled.svg";
+import ico_roundcheck_outline from "../../assets/images/24x24/ico_roundcheck_outline.svg";
 
 const AgreementPage: React.FC = () => {
-    return(
-        <div>hello</div>
+    const [isAllChecked, setIsAllChecked] = useState(false);
+    const [isAgeChecked, setIsAgeChecked] = useState(false);
+    const [isAdChecked, setIsAdChecked] = useState(false);
+
+    const handleAllCheck = () => {
+        const newCheckState = !isAllChecked;
+        setIsAllChecked(newCheckState);
+        setIsAgeChecked(newCheckState);
+        setIsAdChecked(newCheckState);
+    };
+
+    const handleAgeCheck = () => {
+        const newCheckState = !isAgeChecked;
+        setIsAgeChecked(newCheckState);
+        setIsAllChecked(newCheckState && isAdChecked);
+    }
+
+    const handleAdCheck = () => {
+        const newCheckState = !isAdChecked;
+        setIsAdChecked(newCheckState);
+        setIsAllChecked(newCheckState && isAgeChecked);
+    }
+
+    const isFormValid = isAgeChecked;
+
+    return (
+        <div className="w-[390px] mx-auto pt-[72px] bg-[#F8F9FC]">
+            <h1 className="text-2xl font-pretendard font-bold ml-6 mb-[64px]">
+                <span className="text-point500">회원가입</span>을 위한<br />약관에 동의해주세요.
+            </h1>
+            <div className="flex flex-col gap-[24px] mx-[20px]">
+                <div className="w-[352px] h-[54px] bg-[#EDF0F3] p-[12px] border border-1 border-[#9EAAB5] rounded-[8px] flex items-center">
+                    <img 
+                        src={isAllChecked ? ico_roundcheck_filled : ico_roundcheck_outline} 
+                        alt="check icon" 
+                        className="cursor-pointer"
+                        onClick={handleAllCheck}
+                    />
+                    <div className="text-[16px] font-[700] ml-2">아래 약관에 모두 동의합니다.</div>
+                </div>
+
+
+                <div className="w-[334px] flex justify-between items-center ml-[8px]">
+                    <div className="flex items-center justify-start gap-[12px]">
+                        <img 
+                            src={isAgeChecked ? ico_roundcheck_filled : ico_roundcheck_outline} 
+                            alt="check icon" 
+                            className="cursor-pointer"
+                            onClick={handleAgeCheck}
+                        />
+                        <div className="text-[14px] font-[500]">[필수] 만 14세 이상이며 모두 동의합니다.</div>
+                    </div>
+                    <div className="text-[#9EAAB5] text-[12px] font-[400] underline cursor-pointer">내용보기</div>
+                </div>
+
+
+                <div className="w-[334px] flex justify-between items-center ml-[8px]">
+                    <div className="flex items-center justify-start gap-[12px]">
+                        <img 
+                            src={isAdChecked ? ico_roundcheck_filled : ico_roundcheck_outline} 
+                            alt="check icon" 
+                            className="cursor-pointer"
+                            onClick={handleAdCheck}
+                        />
+                        <div className="text-[14px] font-[500]">[선택] 광고성 정보 수신에 모두 동의합니다.</div>
+                    </div>
+                    <div className="text-[#9EAAB5] text-[12px] font-[400] underline cursor-pointer">내용보기</div>
+                </div>
+            </div>
+            <button 
+                className={`w-[352px] h-[48px] ml-[19px] mt-[300px] py-2 rounded flex items-center justify-center font-pretendard font-bold text-[16px] text-white ${isFormValid ? 'bg-point500' : 'bg-gray2'}`}
+                disabled={!isFormValid}
+                style={{ border: 'none', padding: 0, borderRadius: '12px' }}
+            >
+                가입하기
+            </button>
+        </div>
     )
 }
 

--- a/src/pages/AgreementPage/AgreementPage.tsx
+++ b/src/pages/AgreementPage/AgreementPage.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const AgreementPage: React.FC = () => {
+    return(
+        <div>hello</div>
+    )
+}
+
+export default AgreementPage;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -7,8 +7,8 @@ import GreetingMessage from "./component/GreetingMessage";
 
 const HomePage = () => {
   // 여기에 실제 로그인 상태를 확인하는 로직을 추가해야 함
-  // const isLoggedIn = false; 
-  const isLoggedIn = true;
+  const isLoggedIn = false; 
+  // const isLoggedIn = true;
 
   return (
     <div className="bg-[#F8F9FC] w-[390px] mx-auto">

--- a/src/pages/HomePage/component/LiveDiscussion.tsx
+++ b/src/pages/HomePage/component/LiveDiscussion.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import LiveDiscussion1 from '../../../assets/images/LiveDiscussion/LiveDiscussion1.png';
 import LiveDiscussion2 from '../../../assets/images/LiveDiscussion/LiveDiscussion2.png';
 import LiveDiscussion3 from '../../../assets/images/LiveDiscussion/LiveDiscussion3.png';
+import tag_ico_view from "../../../assets/images/16x16/tag_ico_view.svg";
+import tag_ico_comment from "../../../assets/images/16x16/tag_ico_comment.svg";
 
 const discussions = [
   {
@@ -32,10 +34,10 @@ const DiscussionCard = ({ image, hits, comments, title, link }) => (
     <img src={image} alt={title} className="w-[164px] h-[200px] rounded-lg mb-2" />
     <div className="w-[130px] h-6 justify-start items-start gap-2 inline-flex">
       <div className="w-[65px] px-2 py-1 bg-purple-100 rounded-2xl justify-center items-center gap-1 flex">
-        <div className="text-violet-700 text-xs font-medium font-['Pretendard']">{hits}</div>
+        <div className="text-violet-700 text-xs font-medium font-['Pretendard']"><img src={tag_ico_view} alt='tag_ico_view'/>{hits}</div>
       </div>
       <div className="w-[57px] px-2 py-1 bg-purple-100 rounded-2xl justify-center items-center gap-1 flex">
-        <div className="text-violet-700 text-xs font-medium font-['Pretendard']">{comments}</div>
+        <div className="text-violet-700 text-xs font-medium font-['Pretendard']"><img src={tag_ico_comment} alt='tag_ico_view'/>{comments}</div>
       </div>
     </div>
     <a href={link} className="block text-[#1D2228] font-pretendard font-bold text-[16px] leading-[22.4px] no-underline text-center mt-2">

--- a/src/pages/HomePage/component/LiveDiscussion.tsx
+++ b/src/pages/HomePage/component/LiveDiscussion.tsx
@@ -34,10 +34,10 @@ const DiscussionCard = ({ image, hits, comments, title, link }) => (
     <img src={image} alt={title} className="w-[164px] h-[200px] rounded-lg mb-2" />
     <div className="w-[130px] h-6 justify-start items-start gap-2 inline-flex">
       <div className="w-[65px] px-2 py-1 bg-purple-100 rounded-2xl justify-center items-center gap-1 flex">
-        <div className="text-violet-700 text-xs font-medium font-['Pretendard']"><img src={tag_ico_view} alt='tag_ico_view'/>{hits}</div>
+        <div className="flex flex-row gap-[4px] text-violet-700 text-xs font-medium font-['Pretendard']"><img src={tag_ico_view} alt='tag_ico_view'/>{hits}</div>
       </div>
       <div className="w-[57px] px-2 py-1 bg-purple-100 rounded-2xl justify-center items-center gap-1 flex">
-        <div className="text-violet-700 text-xs font-medium font-['Pretendard']"><img src={tag_ico_comment} alt='tag_ico_view'/>{comments}</div>
+        <div className="flex flex-row gap-[4px] text-violet-700 text-xs font-medium font-['Pretendard']"><img src={tag_ico_comment} width={16} height={16} alt='tag_ico_view'/>{comments}</div>
       </div>
     </div>
     <a href={link} className="block text-[#1D2228] font-pretendard font-bold text-[16px] leading-[22.4px] no-underline text-center mt-2">

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -5,11 +5,19 @@ import Visibility from '../../assets/images/visibility.svg';
 
 const Login: React.FC = () => {
     const [email, setEmail] = useState('');
+    const [isEmailValid, setIsEmailValid] = useState(false);
     const [password, setPassword] = useState('');
     const [showPassword, setShowPassword] = useState(false);
 
     const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setEmail(event.target.value);
+        const newEmail = event.target.value;
+        setEmail(newEmail);
+        setIsEmailValid(validateEmail(newEmail));
+    };
+
+    const validateEmail = (email: string) => {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return emailRegex.test(email);
     };
 
     const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,11 +39,8 @@ const Login: React.FC = () => {
                     입니다.
                 </h1>
                 <form className="space-y-4">
-                    <div className="space-y-3">
-                        <label
-                            htmlFor="email"
-                            className="text-[16px] text-black font-[700]"
-                        >
+                    <div className="space-y-3 relative">
+                        <label htmlFor="email" className="text-[16px] text-black font-[700]">
                             이메일
                         </label>
                         <input
@@ -46,12 +51,14 @@ const Login: React.FC = () => {
                             className="w-[352px] h-[54px] pt-[12px] pb-[12px] pl-[20px] text-[18px] bg-[#F8F9FC] rounded-[8px] focus:outline-none text-[black] font-[500]"
                             placeholder="이메일을 입력해주세요"
                         />
+                        {!isEmailValid && email.length > 0 && (
+                            <p className="text-[12px] text-errorpoint font-pretendard font-medium mt-1 ml-2">
+                                이메일 주소를 정확하게 입력해주세요.
+                            </p>
+                        )}
                     </div>
                     <div className="space-y-3 relative">
-                        <label
-                            htmlFor="password"
-                            className="text-[16px] text-black font-[700]"
-                        >
+                        <label htmlFor="password" className="text-[16px] text-black font-[700]">
                             비밀번호
                         </label>
                         <input
@@ -67,10 +74,7 @@ const Login: React.FC = () => {
                             onClick={handleTogglePasswordVisibility}
                             className="absolute inset-y-0 right-0 pt-[25px] flex items-center text-gray-500"
                         >
-                            <img
-                                src={showPassword ? Visibility : NonVisibility}
-                                alt="toggle password visibility"
-                            />
+                            <img src={showPassword ? Visibility : NonVisibility} alt="toggle password visibility" />
                         </button>
                     </div>
                     <div>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요. ( main ❌ / develop ⭕ )
- PR의 제목에도 관련 이슈 번호를 포함시켜 주세요.
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #28 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x]  UI 레이아웃 구현
- [x]  약관 모두 동의 선택 시, 모든 체크박스 표시
- [x] 가입하기 버튼 구현
- [x] '내용보기' 구현

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
![Screenshot 2024-07-30 at 12 55 15 AM](https://github.com/user-attachments/assets/43ad0328-236c-4f62-86c0-027602fdcba4)
![Screenshot 2024-07-30 at 12 55 22 AM](https://github.com/user-attachments/assets/f0663beb-9742-4516-bc9f-cabef8e02990)
![Screenshot 2024-07-30 at 12 55 30 AM](https://github.com/user-attachments/assets/0d498aac-b904-49b2-93e5-a55906bfa919)
![Screenshot 2024-07-30 at 12 55 38 AM](https://github.com/user-attachments/assets/a2f15e8d-936d-4ec7-94de-cba7e0675dfd)



## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
내용보기 라우터는 추후 링크 나오면 달겠습니다.
이번 PR은 홈화면 Best 3 CSS, 로그인 화면 이메일 양식도 추가로 수정했으니 참고해주세요!