### PR TITLE
[REFACTOR/#53]: @path aliases 경로 별칭 추가

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,5 +1,11 @@
 {
   "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "@images/*": ["assets/images/*"],
+      "@components/*": ["components/*"],
+      "@utils/*": ["utils/*"],
+  },
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "skipLibCheck": true,


### PR DESCRIPTION
-@images (아이콘) 폴더
-@components 컴포넌트 폴더
-@utils 유틸리티 함수 폴더

## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요. ( main ❌ / develop ⭕ )
- PR의 제목에도 관련 이슈 번호를 포함시켜 주세요.
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #53

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] tsconfig.node.json 파일에서 기본 경로 설정
- [x] 맵핑 경로 설정 (-@images 아이콘 폴더, components 컴포넌트 폴더, utils 유틸리티 함수 폴더)

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁



## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
아이콘, 컴포넌트, 페이지를 import 할 수록 경로가 너무 복잡해지는 것을 개선하고자 경로 별칭([path aliases](https://dev.to/marcosdiasdev/using-path-aliases-on-create-react-app-projects-686))를 설정했습니다
-@ images (아이콘) 폴더
-@ components 컴포넌트 폴더
-@ utils 유틸리티 함수 폴더

이렇게 설정하면 아래 사진처럼 깔끔하게 경로를 작성할 수 있습니다
![image](https://github.com/user-attachments/assets/588b51db-441f-4940-8819-520533131170)


기존에 vote 브랜치에서 작업하고 있었는데, 개발이 지연되어서 우선 이 기능 먼저 pr 올립니다

