### PR TITLE
[FEAT/#65] 회원가입 서버 통신 프로세스 완료

### DIFF
--- a/src/apis/emailDuplicateCheck.ts
+++ b/src/apis/emailDuplicateCheck.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const emailDuplicateCheck = async (email: string) => {
+  const response = await axios.get(`/auth/email/check`, {
+    params: {
+      email: encodeURIComponent(email),
+    },
+  });
+
+  return response.data;
+};

--- a/src/apis/getEmailVerification.ts
+++ b/src/apis/getEmailVerification.ts
@@ -1,11 +1,12 @@
 import axios from "axios";
 
-export const getEmailVerficiation = async (email: string, code: number) => {
-    const response = await axios.get(
-        `/auth/emails/verifications`, {params: {
-            email: encodeURIComponent(email),
-            code: code
-        }}
-    );
+export const getEmailVerficiation = async (email: string, verificationCode: string) => {
+    const response = await axios.get(`/auth/emails/verifications`, {
+        params: {
+            email: email,
+            code: verificationCode,
+        },
+    });
+
     return response.data;
 }

--- a/src/apis/getEmailVerification.ts
+++ b/src/apis/getEmailVerification.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+export const getEmailVerficiation = async (email: string, code: number) => {
+    const response = await axios.get(
+        `/auth/emails/verifications`, {params: {
+            email: encodeURIComponent(email),
+            code: code
+        }}
+    );
+    return response.data;
+}

--- a/src/apis/nicknameDuplicateCheck.ts
+++ b/src/apis/nicknameDuplicateCheck.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const nicknameDuplicateCheck = async (nickname: string) => {
+  const response = await axios.get(`/auth/nickname/check`, {
+    params: {
+      nickname: nickname,
+    },
+  });
+
+  return response.data;
+};

--- a/src/apis/sendEmailVerification.ts
+++ b/src/apis/sendEmailVerification.ts
@@ -1,10 +1,18 @@
 import axios from "axios";
 
 export const sendEmailVerification = async (email: string) => {
-    const response = await axios.get(`/auth/emails/verification-requests` ,{
+    const response = await axios.post(`/auth/emails/verification-requests`, {
         params: {
-            email: encodeURIComponent(email),
+            email: encodeURIComponent(email), // Request body로 email을 전송
         }
-    });
+
+        }, 
+        {
+            headers: {
+                'Authorization': 'Bearer <token>',  // Authorization 헤더에 토큰 추가
+                'Content-Type': 'application/json', // Content-Type 설정
+            }
+        }
+    );
     return response.data;
 }

--- a/src/apis/sendEmailVerification.ts
+++ b/src/apis/sendEmailVerification.ts
@@ -1,18 +1,17 @@
 import axios from "axios";
 
 export const sendEmailVerification = async (email: string) => {
-    const response = await axios.post(`/auth/emails/verification-requests`, {
+    const response = await axios.post(
+    `/auth/emails/verification-requests`, null,
+    {
         params: {
-            email: encodeURIComponent(email), // Request body로 email을 전송
-        }
-
-        }, 
-        {
-            headers: {
-                'Authorization': 'Bearer <token>',  // Authorization 헤더에 토큰 추가
-                'Content-Type': 'application/json', // Content-Type 설정
-            }
-        }
+            email: email,
+        },
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    }
     );
+
     return response.data;
-}
+  };

--- a/src/apis/sendEmailVerification.ts
+++ b/src/apis/sendEmailVerification.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+export const sendEmailVerification = async (email: string) => {
+    const response = await axios.get(`/auth/emails/verification-requests` ,{
+        params: {
+            email: encodeURIComponent(email),
+        }
+    });
+    return response.data;
+}

--- a/src/apis/signUp.ts
+++ b/src/apis/signUp.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+interface SignUpRequest {
+  email: string;
+  password: string;
+  nickname: string;
+  birth_date: string;
+  likedTopics: string[];
+}
+
+export const signUp = async (request: SignUpRequest) => {
+  const response = await axios.post('/auth/signup', request, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return response.data;
+}

--- a/src/apis/signUp.ts
+++ b/src/apis/signUp.ts
@@ -16,4 +16,4 @@ export const signUp = async (request: SignUpRequest) => {
   });
 
   return response.data;
-}
+};

--- a/src/apis/signUp.ts
+++ b/src/apis/signUp.ts
@@ -9,11 +9,16 @@ interface SignUpRequest {
 }
 
 export const signUp = async (request: SignUpRequest) => {
-  const response = await axios.post('/auth/signup', request, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+  try {
+    const response = await axios.post('/auth/signup', request, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
 
-  return response.data;
+    return response.data; // 응답 데이터의 반환을 보장
+  } catch (error) {
+    console.error('API 요청 중 오류 발생:', error);
+    throw error; // 에러를 호출자에게 전달
+  }
 };

--- a/src/apis/signUp.ts
+++ b/src/apis/signUp.ts
@@ -9,16 +9,11 @@ interface SignUpRequest {
 }
 
 export const signUp = async (request: SignUpRequest) => {
-  try {
-    const response = await axios.post('/auth/signup', request, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+  const response = await axios.post('/auth/signup', request, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
 
-    return response.data; // 응답 데이터의 반환을 보장
-  } catch (error) {
-    console.error('API 요청 중 오류 발생:', error);
-    throw error; // 에러를 호출자에게 전달
-  }
+  return response.data;
 };

--- a/src/assets/images/24x24/ico_code_roundcheck_able.svg
+++ b/src/assets/images/24x24/ico_code_roundcheck_able.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="9.5" fill="#7620E4" stroke="#7620E4"/>
+<path d="M16.6673 8.5L10.2507 14.9167L7.33398 12" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/AgreementPage/AgreementPage.tsx
+++ b/src/pages/AgreementPage/AgreementPage.tsx
@@ -35,9 +35,10 @@ const AgreementPage: React.FC = () => {
     const isFormValid = isAgeChecked;
 
     return (
-        <div className="w-[390px] mx-auto pt-[72px] bg-[#F8F9FC]">
+        <div className="w-[390px] h-screen mx-auto pt-[72px] bg-background font-pretendard">
             <h1 className="text-2xl font-pretendard font-bold ml-6 mb-[64px]">
-                <span className="text-point500">회원가입</span>을 위한<br />약관에 동의해주세요.
+                <span className="text-point500">회원가입</span>
+                <span className="text-black">을 위한<br />약관에 동의해주세요.</span>
             </h1>
             <div className="flex flex-col gap-[24px] mx-[20px]">
                 <div className="w-[352px] h-[54px] bg-[#EDF0F3] p-[12px] border border-1 border-[#9EAAB5] rounded-[8px] flex items-center">
@@ -47,7 +48,7 @@ const AgreementPage: React.FC = () => {
                         className="cursor-pointer"
                         onClick={handleAllCheck}
                     />
-                    <div className="text-[16px] font-[700] ml-2">아래 약관에 모두 동의합니다.</div>
+                    <div className="text-black text-[16px] font-[700] ml-2">아래 약관에 모두 동의합니다.</div>
                 </div>
 
 
@@ -59,9 +60,9 @@ const AgreementPage: React.FC = () => {
                             className="cursor-pointer"
                             onClick={handleAgeCheck}
                         />
-                        <div className="text-[14px] font-[500]">[필수] 만 14세 이상이며 모두 동의합니다.</div>
+                        <div className="text-black text-[14px] font-[500]">[필수] 만 14세 이상이며 모두 동의합니다.</div>
                     </div>
-                    <div className="text-[#9EAAB5] text-[12px] font-[400] underline cursor-pointer">내용보기</div>
+                    <div className="text-gray3 text-[12px] font-[400] underline cursor-pointer">내용 보기</div>
                 </div>
 
 
@@ -73,9 +74,9 @@ const AgreementPage: React.FC = () => {
                             className="cursor-pointer"
                             onClick={handleAdCheck}
                         />
-                        <div className="text-[14px] font-[500]">[선택] 광고성 정보 수신에 모두 동의합니다.</div>
+                        <div className="text-black text-[14px] font-[500]">[선택] 광고성 정보 수신에 모두 동의합니다.</div>
                     </div>
-                    <div className="text-[#9EAAB5] text-[12px] font-[400] underline cursor-pointer">내용보기</div>
+                    <div className="text-gray3 text-[12px] font-[400] underline cursor-pointer">내용 보기</div>
                 </div>
             </div>
             <button 

--- a/src/pages/InterestPage/InterestPage.tsx
+++ b/src/pages/InterestPage/InterestPage.tsx
@@ -5,7 +5,7 @@ import CompleteBtn from "./component/CompleteBtn";
 
 const InterestPage: React.FC = () => {
     return(
-        <div className="w-[390px] bg-background mx-auto px-[32px] font-pretendard">
+        <div className="w-[390px] h-screen bg-background mx-auto px-[32px] font-pretendard">
             <Header/>
             <Item/>
             <CompleteBtn/>

--- a/src/pages/InterestPage/InterestPage.tsx
+++ b/src/pages/InterestPage/InterestPage.tsx
@@ -5,7 +5,7 @@ import CompleteBtn from "./component/CompleteBtn";
 
 const InterestPage: React.FC = () => {
     return(
-        <div className="w-[390px] bg-background mx-auto px-[32px]">
+        <div className="w-[390px] bg-background mx-auto px-[32px] font-pretendard">
             <Header/>
             <Item/>
             <CompleteBtn/>

--- a/src/pages/InterestPage/component/CompleteBtn.tsx
+++ b/src/pages/InterestPage/component/CompleteBtn.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
 import { useSignUpContext } from '../../../context/SignUpContext';
+import { signUp } from '../../../apis/signUp';
 
 
 const CompleteBtn: React.FC = () => {
@@ -10,7 +10,7 @@ const CompleteBtn: React.FC = () => {
 
     const handleClick = async () => {
         try {
-            const requestData = {
+            const request = {
                 email,
                 password,
                 nickname,
@@ -18,11 +18,7 @@ const CompleteBtn: React.FC = () => {
                 likedTopics
             };
 
-            const response = await axios.post('/auth/signup', requestData, {
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-            });
+            const response = await signUp(request);
 
             if (response.data.code === 1000) {
                 // 요청 성공 시

--- a/src/pages/InterestPage/component/CompleteBtn.tsx
+++ b/src/pages/InterestPage/component/CompleteBtn.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useSignUpContext } from '../../../context/SignUpContext';
-import { signUp } from '../../../apis/signUp';
+// import { signUp } from '../../../apis/signUp';
+import axios from 'axios';
 
 
 const CompleteBtn: React.FC = () => {
@@ -10,7 +11,7 @@ const CompleteBtn: React.FC = () => {
 
     const handleClick = async () => {
         try {
-            const request = {
+            const requestData = {
                 email,
                 password,
                 nickname,
@@ -18,7 +19,11 @@ const CompleteBtn: React.FC = () => {
                 likedTopics
             };
 
-            const response = await signUp(request);
+            const response = await axios.post('/auth/signup', requestData, {
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            });
 
             if (response.data.code === 1000) {
                 // 요청 성공 시

--- a/src/pages/InterestPage/component/CompleteBtn.tsx
+++ b/src/pages/InterestPage/component/CompleteBtn.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useSignUpContext } from '../../../context/SignUpContext';
-// import { signUp } from '../../../apis/signUp';
-import axios from 'axios';
+import { signUp } from '../../../apis/signUp';
 
 
 const CompleteBtn: React.FC = () => {
@@ -11,7 +10,7 @@ const CompleteBtn: React.FC = () => {
 
     const handleClick = async () => {
         try {
-            const requestData = {
+            const request = {
                 email,
                 password,
                 nickname,
@@ -19,19 +18,15 @@ const CompleteBtn: React.FC = () => {
                 likedTopics
             };
 
-            const response = await axios.post('/auth/signup', requestData, {
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-            });
+            const response = await signUp(request);
 
-            if (response.data.code === 1000) {
+            if (response.code === 1000) {
                 // 요청 성공 시
-                console.log('회원가입 성공:', response.data);
+                console.log('회원가입 성공:', response);
                 navigate('/');
             } else {
                 // 요청 실패 시
-                console.error('회원가입 실패:', response.data.message);
+                console.error('회원가입 실패:', response.message);
             }
         } catch (error) {
             console.error('회원가입 중 오류 발생:', error);

--- a/src/pages/InterestPage/component/CompleteBtn.tsx
+++ b/src/pages/InterestPage/component/CompleteBtn.tsx
@@ -33,7 +33,7 @@ const CompleteBtn: React.FC = () => {
         }
     }
     return(
-        <button className="mx-auto mt-[90px] mb-[66px] w-[325px] h-[48px] text-[white] bg-point500 rounded-[12px]" onClick={handleClick}>
+        <button className="mx-auto mt-[90px] mb-[66px] w-[325px] h-[48px] text-[white] text-[16px] font-bold bg-point500 rounded-[12px]" onClick={handleClick}>
             완료</button>
     )
 }

--- a/src/pages/InterestPage/component/CompleteBtn.tsx
+++ b/src/pages/InterestPage/component/CompleteBtn.tsx
@@ -20,16 +20,13 @@ const CompleteBtn: React.FC = () => {
 
             const response = await signUp(request);
 
-            if (response && response.data.code === 1000) {
+            if (response.data.code === 1000) {
                 // 요청 성공 시
                 console.log('회원가입 성공:', response.data);
                 navigate('/');
-            } else if (response && response.message) {
-                // 요청 실패 시
-                console.error('회원가입 실패:', response.message);
             } else {
-                // 예기치 않은 응답 형식
-                console.error('예기치 않은 응답:', response);
+                // 요청 실패 시
+                console.error('회원가입 실패:', response.data.message);
             }
         } catch (error) {
             console.error('회원가입 중 오류 발생:', error);

--- a/src/pages/InterestPage/component/CompleteBtn.tsx
+++ b/src/pages/InterestPage/component/CompleteBtn.tsx
@@ -20,13 +20,16 @@ const CompleteBtn: React.FC = () => {
 
             const response = await signUp(request);
 
-            if (response.data.code === 1000) {
+            if (response && response.data.code === 1000) {
                 // 요청 성공 시
                 console.log('회원가입 성공:', response.data);
                 navigate('/');
-            } else {
+            } else if (response && response.message) {
                 // 요청 실패 시
-                console.error('회원가입 실패:', response.data.message);
+                console.error('회원가입 실패:', response.message);
+            } else {
+                // 예기치 않은 응답 형식
+                console.error('예기치 않은 응답:', response);
             }
         } catch (error) {
             console.error('회원가입 중 오류 발생:', error);

--- a/src/pages/InterestPage/component/Item.tsx
+++ b/src/pages/InterestPage/component/Item.tsx
@@ -54,7 +54,7 @@ const Item: React.FC = () => {
                             </object>
                         </div>
                     </div>
-                    <div className="cursor-pointer">{item.topic}</div>
+                    <div className="cursor-pointer font-medium">{item.topic}</div>
                 </button>
             ))}
         </div>

--- a/src/pages/SetProfile/Keypad.tsx
+++ b/src/pages/SetProfile/Keypad.tsx
@@ -39,7 +39,7 @@ const Inputter: React.FC<InputterProps> = ({ value, onChange }) => {
   }, [onChange]);
 
   return (
-      <div className="absolute flex flex-col justify-center items-between bottom-0 w-[352px] h-[300px] mx-auto p-4 bg-white">
+      <div className="absolute flex flex-col justify-center items-between bottom-0 w-[352px] h-[300px] mx-auto p-4 bg-background">
       <div className="grid grid-cols-3 mb-3 ">
         {nums.slice(0, 9).map((n, i) => (
           <button

--- a/src/pages/SetProfile/NewSetProfile.tsx
+++ b/src/pages/SetProfile/NewSetProfile.tsx
@@ -6,13 +6,20 @@ import { useSignUpContext } from '../../context/SignUpContext';
 const NewSetProfile: React.FC = () => {
   const { nickname, setNickname, birthDate, setBirthDate } = useSignUpContext();
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+  const [nicknameError, setNicknameError] = useState(false);
   const [birthdateError, setBirthdateError] = useState(false);
   const birthdateRef = useRef<HTMLInputElement>(null);
   const keypadRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
 
   const handleNicknameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setNickname(event.target.value);
+    const value = event.target.value;
+    if (value.length > 10) {
+      setNicknameError(true);
+    } else {
+      setNicknameError(false);
+      setNickname(value);
+    }
   };
 
   const handleBirthdateChange = (value: string) => {
@@ -51,7 +58,7 @@ const NewSetProfile: React.FC = () => {
   const isFormValid = nickname.length > 0 && birthDate.length === 8;
 
   return (
-    <div className="flex w-[390px] h-[800px] mt-[70px] justify-center min-h-screen mx-auto">
+    <div className="flex w-[390px] h-[800px] pt-[70px] justify-center min-h-screen mx-auto font-pretendard bg-background">
       <div className="w-full max-w-md p-[20px] rounded-lg">
         <h1 className="text-[24px] font-[700] mb-[52px]">
           <div>잇픽에 필요한</div>{' '}
@@ -66,9 +73,14 @@ const NewSetProfile: React.FC = () => {
               id="nickname"
               value={nickname}
               onChange={handleNicknameChange}
-              className="w-[352px] h-[54px] pt-[12px] pb-[12px] pl-[20px] text-[18px] text-[black] font-[500] bg-[#F8F9FC] rounded-[8px] focus:outline-none"
+              className="w-[352px] h-[54px] pt-[12px] pb-[12px] pl-[20px] text-[18px] text-[black] font-[500] bg-gray1 rounded-[8px] focus:outline-none"
               placeholder="닉네임을 입력해주세요 (10자 이하)"
             />
+            {nicknameError && (
+              <span className="text-errorpoint text-[12px] font-medium ml-3">
+                닉네임을 10자 이내로 작성해주세요.
+              </span>
+            )}
           </div>
 
           <div className="space-y-3 relative">
@@ -82,11 +94,11 @@ const NewSetProfile: React.FC = () => {
               ref={birthdateRef}
               onFocus={() => setIsKeyboardVisible(true)}
               readOnly
-              className=" w-[352px] h-[54px] pt-[12px] pb-[12px] pl-[20px] text-[black] font-[500] text-[18px] bg-[#F8F9FC] rounded-[8px] focus:outline-none"
+              className=" w-[352px] h-[54px] pt-[12px] pb-[12px] pl-[20px] text-[black] font-[500] text-[18px] bg-gray1 rounded-[8px] focus:outline-none"
               placeholder="8자리 숫자로 입력해주세요"
             />
             {birthdateError && (
-              <span className="text-errorpoint text-[14px]">
+              <span className="text-errorpoint text-[12px] font-medium ml-3">
                 생년월일을 확인해주세요.
               </span>
             )}

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -13,6 +13,7 @@ const SignUpPage: React.FC = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [emailValidationMessage, setEmailValidationMessage] = useState<string | null>(null);
+  const [isEmailValidated, setIsEmailValidated] = useState(false);
   
   const navigate = useNavigate();
 
@@ -23,6 +24,7 @@ const SignUpPage: React.FC = () => {
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value);
     setEmailValidationMessage(null);
+    setIsEmailValidated(false);
   };
 
   const handleEmailValidation = async () => {
@@ -34,11 +36,11 @@ const SignUpPage: React.FC = () => {
         });
         
         if (response.data.code === 1000) {
-            console.log('사용 가능한 이메일 !');
             setEmailValidationMessage('사용 가능한 이메일 입니다.');
+            setIsEmailValidated(true);
         } else {
-            console.log('사용 불가능한 이메일 ㅜㅜ');
             setEmailValidationMessage('사용 불가능한 이메일 입니다.');
+            setIsEmailValidated(false);
         }
     } catch (error) {
         if (axios.isAxiosError(error) && error.response) {
@@ -47,6 +49,7 @@ const SignUpPage: React.FC = () => {
             console.error('이메일 유효성 검사 중 오류 발생:', error);
         }
         setEmailValidationMessage('사용 불가능한 이메일 입니다.');
+        setIsEmailValidated(false);
     }
 };
 
@@ -77,7 +80,7 @@ const SignUpPage: React.FC = () => {
   };
 
   const isFormValid =
-    (step === 1 && isEmailValid) ||
+    (step === 1 && isEmailValid && isEmailValidated) ||
     (step === 2 && isVerificationCodeValid) ||
     (step === 3 && isPasswordValid) ||
     (step === 4 && password === confirmPassword);

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import InputField from './components/InputField';
-import axios from 'axios';
 import { validateEmail, validateVerificationCode, validatePassword } from './utils/validation';
 import { useSignUpContext } from '../../context/SignUpContext';
+import { emailDuplicateCheck } from '../../apis/emailDuplicateCheck';
 
 const SignUpPage: React.FC = () => {
   const { email, setEmail, password, setPassword } = useSignUpContext();
@@ -29,27 +29,19 @@ const SignUpPage: React.FC = () => {
 
   const handleEmailValidation = async () => {
     try {
-        const response = await axios.get(`/auth/email/check`, {
-            params: {
-                email: encodeURIComponent(email)
-            }
-        });
-        
-        if (response.data.code === 1000) {
-            setEmailValidationMessage('사용 가능한 이메일 입니다.');
-            setIsEmailValidated(true);
-        } else {
-            setEmailValidationMessage('사용 불가능한 이메일 입니다.');
-            setIsEmailValidated(false);
-        }
+      const data = await emailDuplicateCheck(email);
+      
+      if (data.code === 1000) {
+          setEmailValidationMessage('사용 가능한 이메일 입니다.');
+          setIsEmailValidated(true);
+      } else {
+          setEmailValidationMessage('사용 불가능한 이메일 입니다.');
+          setIsEmailValidated(false);
+      }
     } catch (error) {
-        if (axios.isAxiosError(error) && error.response) {
-            console.error('이메일 유효성 검사 중 오류 발생:', error.response.data);
-        } else {
-            console.error('이메일 유효성 검사 중 오류 발생:', error);
-        }
-        setEmailValidationMessage('사용 불가능한 이메일 입니다.');
-        setIsEmailValidated(false);
+      console.error('이메일 유효성 검사 중 오류 발생:', error);
+      setEmailValidationMessage('사용 불가능한 이메일 입니다.');
+      setIsEmailValidated(false);
     }
 };
 

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -106,6 +106,8 @@ const SignUpPage: React.FC = () => {
     }
   };
 
+  const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
   const isFormValid =
     (step === 1 && isEmailValid && isEmailValidated) ||
     (step === 2 && isVerificationCodeValid && verificationCode.length === 6) ||
@@ -191,8 +193,9 @@ const SignUpPage: React.FC = () => {
                 handleEmailVerification(); // step이 1일 때 handleEmailVerification 호출
                 handleNextStep();
               } else if (step === 2) {
-                handleCodeVerification();
-                handleNextStep();
+                handleCodeVerification().then(() => {
+                  delay(500).then(handleNextStep);
+                });
               } else {
                 handleNextStep(); // 그 외의 경우는 기존의 handleNextStep 호출
               }

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -33,6 +33,7 @@ const SignUpPage: React.FC = () => {
       
       if (data.code === 1000) {
           setEmailValidationMessage('사용 가능한 이메일 입니다.');
+          console.log('사용 가능 이메일', data);
           setIsEmailValidated(true);
       } else {
           setEmailValidationMessage('사용 불가능한 이메일 입니다.');
@@ -60,7 +61,7 @@ const SignUpPage: React.FC = () => {
   };
 
   const handleNextStep = () => {
-    if (step === 1 && isEmailValid) setStep(2);
+    if (step === 1 && isEmailValid && isEmailValidated) setStep(2);
     if (step === 2 && isVerificationCodeValid) setStep(3);
     if (step === 3 && isPasswordValid) setStep(4);
   };

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -5,6 +5,7 @@ import { validateEmail, validateVerificationCode, validatePassword } from './uti
 import { useSignUpContext } from '../../context/SignUpContext';
 import { emailDuplicateCheck } from '../../apis/emailDuplicateCheck';
 import { sendEmailVerification } from '../../apis/sendEmailVerification';
+import { getEmailVerficiation } from '../../apis/getEmailVerification';
 
 const SignUpPage: React.FC = () => {
   const { email, setEmail, password, setPassword } = useSignUpContext();
@@ -15,6 +16,7 @@ const SignUpPage: React.FC = () => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [emailValidationMessage, setEmailValidationMessage] = useState<string | null>(null);
   const [isEmailValidated, setIsEmailValidated] = useState(false);
+  const [isCodeValidated, setIsCodeValidated] = useState(false);
   
   const navigate = useNavigate();
 
@@ -45,27 +47,38 @@ const SignUpPage: React.FC = () => {
       setEmailValidationMessage('사용 불가능한 이메일 입니다.');
       setIsEmailValidated(false);
     }
-};
+  };
 
-const handleEmailVerification = async () => {
-  try {
-    const data = await sendEmailVerification(email);
+  const handleEmailVerification = async () => {
+    try {
+      const data = await sendEmailVerification(email);
 
-    if (data.code === 1000) {
-      console.log('인증 요청 성공');
-    } else {
-      console.log("실패", data.message);
-    }
-  } catch (error) {
-    if (error.message === 'Network Error') {
-      console.log('네트워크 오류: 서버에 접근할 수 없습니다.');
-    } else if (error.response) {
+      if (data.code === 1000) {
+        console.log('인증 요청 성공');
+      } else {
+        console.log("실패", data.message);
+      }
+    } catch (error) {
       console.log('인증 요청 실패:', error.response.data.message);
-    } else {
-      console.log('알 수 없는 오류 발생:', error.message);
+    }
+  };
+
+  const handleCodeVerification = async () => {
+    try {
+      const data = await getEmailVerficiation(email, verificationCode);
+
+      if (data.code === 1000) {
+        console.log('인증 성공', data);
+        setIsCodeValidated(true);
+      } else {
+        console.log('인증 실패:', data.message);
+        setIsCodeValidated(false);
+      }
+    } catch (error) {
+      console.error('인증 번호 확인 중 오류 발생:', error);
+      setIsCodeValidated(false);
     }
   }
-};
 
   const handleVerificationCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.value.length <= 6) {
@@ -95,7 +108,7 @@ const handleEmailVerification = async () => {
 
   const isFormValid =
     (step === 1 && isEmailValid && isEmailValidated) ||
-    (step === 2 && isVerificationCodeValid) ||
+    (step === 2 && isVerificationCodeValid && verificationCode.length === 6) ||
     (step === 3 && isPasswordValid) ||
     (step === 4 && password === confirmPassword);
 
@@ -130,6 +143,7 @@ const handleEmailVerification = async () => {
             placeholder="인증번호를 입력해주세요"
             maxLength={6}
             isValid={isVerificationCodeValid}
+            isCodeValid={isCodeValidated}
             showCodeCheck={true}
           />
         </div>
@@ -175,6 +189,9 @@ const handleEmailVerification = async () => {
             onClick={() => {
               if (step === 1) {
                 handleEmailVerification(); // step이 1일 때 handleEmailVerification 호출
+                handleNextStep();
+              } else if (step === 2) {
+                handleCodeVerification();
                 handleNextStep();
               } else {
                 handleNextStep(); // 그 외의 경우는 기존의 handleNextStep 호출

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -4,6 +4,7 @@ import InputField from './components/InputField';
 import { validateEmail, validateVerificationCode, validatePassword } from './utils/validation';
 import { useSignUpContext } from '../../context/SignUpContext';
 import { emailDuplicateCheck } from '../../apis/emailDuplicateCheck';
+import { sendEmailVerification } from '../../apis/sendEmailVerification';
 
 const SignUpPage: React.FC = () => {
   const { email, setEmail, password, setPassword } = useSignUpContext();
@@ -44,6 +45,20 @@ const SignUpPage: React.FC = () => {
       setEmailValidationMessage('사용 불가능한 이메일 입니다.');
       setIsEmailValidated(false);
     }
+};
+
+const handleEmailVerification = async () => {
+  try {
+    const data = await sendEmailVerification(email);
+
+    if(data.code === 1000){
+      console.log('인증 요청 성공');
+    }
+  }
+  catch(error){
+    console.log('인증 요청 실패', error);
+
+  }
 };
 
   const handleVerificationCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -151,7 +166,14 @@ const SignUpPage: React.FC = () => {
         <div className="w-[352px] mx-auto" style={{ position: 'absolute', bottom: '46px', left: '0', right: '0' }}>
           <button
             className={`w-full h-[48px] py-2 rounded flex items-center justify-center font-pretendard font-bold text-[16px] text-white ${isFormValid ? 'bg-point500' : 'bg-gray2'}`}
-            onClick={handleNextStep}
+            onClick={() => {
+              if (step === 1) {
+                handleEmailVerification(); // step이 1일 때 handleEmailVerification 호출
+                handleNextStep();
+              } else {
+                handleNextStep(); // 그 외의 경우는 기존의 handleNextStep 호출
+              }
+            }}
             disabled={step === 1 && !isEmailValid || step === 2 && !isVerificationCodeValid || step === 3 && !isPasswordValid}
             style={{ border: 'none', padding: 0, borderRadius: '12px' }}
           >

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -51,13 +51,19 @@ const handleEmailVerification = async () => {
   try {
     const data = await sendEmailVerification(email);
 
-    if(data.code === 1000){
+    if (data.code === 1000) {
       console.log('인증 요청 성공');
+    } else {
+      console.log("실패", data.message);
     }
-  }
-  catch(error){
-    console.log('인증 요청 실패', error);
-
+  } catch (error) {
+    if (error.message === 'Network Error') {
+      console.log('네트워크 오류: 서버에 접근할 수 없습니다.');
+    } else if (error.response) {
+      console.log('인증 요청 실패:', error.response.data.message);
+    } else {
+      console.log('알 수 없는 오류 발생:', error.message);
+    }
   }
 };
 

--- a/src/pages/SignUpPage/components/InputField.tsx
+++ b/src/pages/SignUpPage/components/InputField.tsx
@@ -17,6 +17,7 @@ interface InputFieldProps {
   showCodeCheck?: boolean;
   showToggle?: boolean;
   onToggle?: () => void;
+  onValidate?: () => void;
   isToggled?: boolean;
   maxLength?: number;
 }
@@ -32,9 +33,12 @@ const InputField: React.FC<InputFieldProps> = ({
   showCodeCheck,
   showToggle,
   onToggle,
+  onValidate,
   isToggled,
   maxLength,
 }) => {
+  const errorClass = errorMessage === '사용 가능한 이메일 입니다.' ? 'text-black' : 'text-errorpoint';
+
   return (
     <div className="mb-4">
       <div className="relative mx-5 mt-2">
@@ -52,6 +56,7 @@ const InputField: React.FC<InputFieldProps> = ({
             <button
               type="button"
               className="absolute right-[12px] h-[54px] flex items-center justify-center"
+              onClick={onValidate}
               disabled={!isValid}
             >
               <img src={isValid ? certifyAble : certifyUnable} alt="email validation" />
@@ -71,7 +76,9 @@ const InputField: React.FC<InputFieldProps> = ({
           )}
         </div>
         {isValid === false && value.length > 0 && (
-          <p className="text-[12px] text-errorpoint font-pretendard font-medium mt-1 ml-3">{errorMessage}</p>
+          <p className={`text-[12px] font-pretendard font-medium mt-1 ml-3 ${errorClass}`}>
+            {errorMessage}
+          </p>
         )}
       </div>
     </div>

--- a/src/pages/SignUpPage/components/InputField.tsx
+++ b/src/pages/SignUpPage/components/InputField.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import certifyUnable from '../../../assets/images/ic_btn_certify_unable.svg';
 import certifyAble from '../../../assets/images/ic_btn_certify_able.svg';
 import codeUnable from '../../../assets/images/24x24/ico_code_roundcheck_unable.svg';
-import codeAble from '../../../assets/images/24x24/ico_code_roundcheck_unable.svg';
+import codeAble from '../../../assets/images/24x24/ico_code_roundcheck_able.svg';
 import hideIcon from '../../../assets/images/ic_icon_hide.svg';
 import showIcon from '../../../assets/images/ic_icon_show.svg';
 
@@ -12,6 +12,7 @@ interface InputFieldProps {
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder: string;
   isValid?: boolean;
+  isCodeValid?: boolean;
   errorMessage?: string;
   showValidationButton?: boolean;
   showCodeCheck?: boolean;
@@ -28,6 +29,7 @@ const InputField: React.FC<InputFieldProps> = ({
   onChange,
   placeholder,
   isValid,
+  isCodeValid,
   errorMessage,
   showValidationButton,
   showCodeCheck,
@@ -63,7 +65,7 @@ const InputField: React.FC<InputFieldProps> = ({
             </button>
           )}
           {showCodeCheck && (
-            <img src={isValid ? codeAble : codeUnable} alt="code verification" className="absolute right-[12px]" />
+            <img src={isCodeValid ? codeAble : codeUnable} alt="code verification" className="absolute right-[12px]" />
           )}
           {showToggle && (
             <button


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요. ( main ❌ / develop ⭕ )
- PR의 제목에도 관련 이슈 번호를 포함시켜 주세요.
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #65

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] 이메일 중복 확인 요청 GET API 연결
- [x] 닉네임 중복 확인 요청 GET API 연결
- [x] 이메일 인증코드 요청 POST API 연결
- [x] 이메일 인증코드 확인 GET API 연결
- [x] 회원가입 서버 통신 리팩토링
- [x] 프로필 설정 페이지 css 수정
- [x] 회원가입 전체 프로세스 연결 (인증코드 요청 구현 후)

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
[실시간 커뮤니티, 잇픽 - Chrome 2024-08-15 20-05-56.webm](https://github.com/user-attachments/assets/a8d40acc-78d6-4be4-bec8-8c4a3dd01a4f)

<img width="1157" alt="화면 캡처 2024-08-15 210016" src="https://github.com/user-attachments/assets/20d56aad-8e44-4b17-b1fb-5cc33b23bf4d">


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
회원가입 프로세스 끝-!-! 😂
각자 회원가입 한번 진행해보고 위 사진처럼 콘솔에 로그도 잘 뜬다면 알려주세요-!

+) 인증코드 확인 후 체크 표시가 뜨고 난 다음에 비밀번호 필드가 떴으면 좋겠어서 
중간에 0.5초 delay 적용했습니다.