### PR TITLE
[FEAT/#55] 모든 브라우저에서 랭킹 카테고리, 전체 페이지 스크롤 바 숨김 구현

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,14 @@ body {
     -ms-overflow-style: none; /* IE and Edge */
     scrollbar-width: none; /* Firefox */
   }
+
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  
+  /* Firefox 용 */
+  body {
+    scrollbar-width: none; /* Firefox에서 스크롤바 너비를 없앱니다 */
+    -ms-overflow-style: none; /* IE, Edge에서 스크롤바를 없앱니다 */
+  }

--- a/src/pages/RankingPage/components/CategorySlider.tsx
+++ b/src/pages/RankingPage/components/CategorySlider.tsx
@@ -25,19 +25,9 @@ const CategorySlider: React.FC<CategorySliderProps> = ({ setCommunityType }) => 
   return (
     <div className="relative">
       <div
-        className="flex overflow-x-auto whitespace-nowrap bg-background pt-2 px-5"
-        style={{
-          scrollbarWidth: 'none',
-          msOverflowStyle: 'none',
-        }}
+        className="flex overflow-x-auto whitespace-nowrap bg-background pt-2 px-5 scrollbar-hidden"
       >
-        <style>
-          {`
-            .category-slider::-webkit-scrollbar {
-              display: none;
-            }
-          `}
-        </style>
+
         {categories.map((category, index) => (
           <div
             key={index}


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요. ( main ❌ / develop ⭕ )
- PR의 제목에도 관련 이슈 번호를 포함시켜 주세요.
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #55

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] 랭킹 카테고리 사파리에서 슬라이드 숨김 구현
`index.css`에 `scrollbar-hidden` 클래스명 사용시 모든 브라우저에서 스크롤바 숨겨지게 해둬서 `className='scrollbar-hidden'` 사용하면 자동 적용 됩니다. 참고하세요

- [x] 모든 페이지에서 오른쪽에 나타나는 슬라이드 바 숨김 ( 크롬, 사파리에서 숨겨지는것 확인했습니다)

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

https://github.com/user-attachments/assets/2c88695e-dbb7-4c39-ac0e-a25d4ae2b2f2




## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
🌊🌊어어푸🏊🏻‍♂️어푸🏊🏻‍♂️어푸🏊🏻‍♂️어푸푸🏊🏻‍♂️🐬🌊🌊
