### PR TITLE
[FEAT/#86] 검색 페이지 API 연결 및 로컬 스토리지 구현, 홈화면 실시간 시간 수정

### DIFF
--- a/src/assets/images/LiveDiscussion/PurpleBox.tsx
+++ b/src/assets/images/LiveDiscussion/PurpleBox.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const PurpleBox = () => {
+  return (
+    <div style={{
+      width: '164px',
+      height: '200px',
+      backgroundColor: '#7620E4',
+      borderRadius: '16px'
+    }}>
+      {/* box 내부 콘텐츠 */}
+    </div>
+  );
+};
+
+export default PurpleBox;

--- a/src/assets/images/ico_purple_box.svg
+++ b/src/assets/images/ico_purple_box.svg
@@ -1,0 +1,3 @@
+<svg width="164" height="200" viewBox="0 0 164 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="164" height="200" fill="#7620E4"/>
+</svg>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -10,21 +10,33 @@ interface SearchBarProps {
 const SearchBar: React.FC<SearchBarProps> = ({ placeholder, onSearch, onSearchAll }) => {
   const [searchTerm, setSearchTerm] = useState('');
 
-  // const handleSearch = () => {
-  //   onSearch(searchTerm);
-  // };
+  const saveSearchTermToLocalStorage = (term: string) => {
+    let storedTags = JSON.parse(localStorage.getItem('recentSearches') || '[]');
+    if (!storedTags.includes(term)) {
+      storedTags = [term, ...storedTags];
+      if (storedTags.length > 3) storedTags.pop(); // 최근 검색어가 3개를 넘지 않도록 제한
+      localStorage.setItem('recentSearches', JSON.stringify(storedTags));
+    }
+  };
+
+  const handleSearch = () => {
+    if (searchTerm.trim() !== '') {
+      saveSearchTermToLocalStorage(searchTerm);
+      onSearch(searchTerm);
+    }
+  };
 
     //엔터 눌렀을 때 검색
   const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
-      onSearch(searchTerm);
+      handleSearch();
     }
   };
   
   //돋보기 버튼 눌렀을 때 검색
   const handleClick = () => {
     if (onSearchAll) {
-      onSearch(searchTerm);
+      handleSearch();
     }
   };
   
@@ -42,7 +54,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ placeholder, onSearch, onSearchAl
         onKeyPress={handleKeyPress}
         className="pl-4 pr-12 py-2 w-full rounded-full border border-transparent focus:outline-none placeholder-gray2 font-pretendard font-normal text-[16px]" 
       />
-      <button onClick={()=> onSearch(searchTerm)} className="absolute right-4 top-1/2 transform -translate-y-1/2">
+      <button onClick={handleSearch} className="absolute right-4 top-1/2 transform -translate-y-1/2">
         <img src={ico_search} alt="Search Icon" className="w-5 h-5" />
       </button>
     </div>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,7 +1,7 @@
 import React,{ useEffect, useState } from 'react';
 import Header from "./component/Header";
 import { useNavigate } from 'react-router-dom';
-import SearchBar from "@components/SearchBar";
+import SearchBar from "./component/SearchBar";
 import IntegratedRanking from "./component/IntegratedRanking";
 import LiveDiscussion from "./component/LiveDiscussion";
 import CommunityRanking from "./component/CommunityRanking";
@@ -23,8 +23,8 @@ const HomePage = () => {
     }
   }, []);
 
-  const handleSearch = (term: string) => {
-    navigate('/search', { state: { searchTerm: term } });
+  const handleNavigateToSearch = () => {
+    navigate('/search');
   };
 
   return (
@@ -33,7 +33,7 @@ const HomePage = () => {
       <GreetingMessage isLoggedIn={isLoggedIn} />
       <div className="flex items-center ml-[24px] mr-[24px] mt-4">
         <img src={logo} alt="Logo Icon" className="w-8 h-8 mr-[14.79px]" />
-        <SearchBar placeholder="김현주 열애설" onSearch={handleSearch} onSearchAll={true} />
+        <SearchBar placeholder="김현주 열애설" onClick={handleNavigateToSearch} />
       </div>
       <IntegratedRanking />
       <LiveDiscussion />

--- a/src/pages/HomePage/component/CommunityRanking.tsx
+++ b/src/pages/HomePage/component/CommunityRanking.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import tag_ico_right from "@images/16x16/tag_ico_right.svg";
 import namuwiki from '@images/CommunityLogo/namuwiki.svg';
 import naver from '@images/CommunityLogo/naver.svg';
@@ -15,11 +15,27 @@ const rankings = [
 ];
 
 const CommunityRanking: React.FC = () => {
+  const [currentTime, setCurrentTime] = useState('');
+
+  const updateCurrentTime = () => {
+    const now = new Date();
+    const month = String(now.getMonth() + 1).padStart(2);
+    const day = String(now.getDate()).padStart(2, '0');
+    const hour = String(now.getHours()).padStart(2, '0');
+    
+    const formattedTime = `${month}월 ${day}일 ${hour}:00 기준`;
+    setCurrentTime(formattedTime);
+  };
+
+  useEffect(() => {
+    updateCurrentTime();
+  }, []);
+
   return (
     <div className=" pt-[44px]  pb-[33px] ">
       <span className='ml-[24px]'>
         <span className="text-[#2E333B] font-pretendard text-[20px] font-bold leading-normal">커뮤니티 별 랭킹</span>
-        <span className="text-xs text-gray-400 ml-[8px]">4월 1일 18:00 기준</span>
+        <span className="text-xs text-gray-400 ml-[8px]">{currentTime}</span>
       </span>
       <span className="ml-[43px]">
         <div className="inline-flex items-center justify-start">

--- a/src/pages/HomePage/component/CommunityRanking.tsx
+++ b/src/pages/HomePage/component/CommunityRanking.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import tag_ico_right from "@images/16x16/tag_ico_right.svg";
 import namuwiki from '@images/CommunityLogo/namuwiki.svg';
 import naver from '@images/CommunityLogo/naver.svg';
@@ -15,6 +16,7 @@ const rankings = [
 ];
 
 const CommunityRanking: React.FC = () => {
+  const navigate = useNavigate();
   const [currentTime, setCurrentTime] = useState('');
 
   const updateCurrentTime = () => {
@@ -31,13 +33,17 @@ const CommunityRanking: React.FC = () => {
     updateCurrentTime();
   }, []);
 
+  const handleRankingClick = () => {
+    navigate('/ranking');
+  };
+
   return (
     <div className=" pt-[44px]  pb-[33px] ">
       <span className='ml-[24px]'>
         <span className="text-[#2E333B] font-pretendard text-[20px] font-bold leading-normal">커뮤니티 별 랭킹</span>
         <span className="text-xs text-gray-400 ml-[8px]">{currentTime}</span>
       </span>
-      <span className="ml-[43px]">
+      <span className="ml-[43px] cursor-pointer" onClick={handleRankingClick}>
         <div className="inline-flex items-center justify-start">
           <span className="w-[50px] h-5 text-right text-gray-400 text-sm font-medium font-['Pretendard']">랭킹보기</span>
           <img src={tag_ico_right} alt="tag_ico_right" />

--- a/src/pages/HomePage/component/IntegratedRanking.tsx
+++ b/src/pages/HomePage/component/IntegratedRanking.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import tag_ico_right from "@images/16x16/tag_ico_right.svg";
 
@@ -30,6 +30,21 @@ const RankingItem = ({ rank, name, tags }) => (
 
 const IntegratedRanking: React.FC = () => {
   const navigate = useNavigate();
+  const [currentTime, setCurrentTime] = useState('');
+
+  const updateCurrentTime = () => {
+    const now = new Date();
+    const month = String(now.getMonth() + 1).padStart(2);
+    const day = String(now.getDate()).padStart(2, '0');
+    const hour = String(now.getHours()).padStart(2, '0');
+    
+    const formattedTime = `${month}월 ${day}일 ${hour}:00 기준`;
+    setCurrentTime(formattedTime);
+  };
+
+  useEffect(() => {
+    updateCurrentTime();
+  }, []);
 
   const handleRankingClick = () => {
     navigate('/ranking');
@@ -40,7 +55,7 @@ const IntegratedRanking: React.FC = () => {
       <div className="flex justify-between items-center w-full mb-[16px]">
         <div className="flex items-center">
           <span className="text-[#2E333B] font-pretendard text-[20px] font-bold leading-normal">통합 랭킹</span>
-          <span className="text-xs text-gray-400 ml-[8px]">4월 1일 18:00 기준</span>
+          <span className="text-xs text-gray-400 ml-[8px]">{currentTime}</span>
         </div>
         <span className="ml-[43px] cursor-pointer" onClick={handleRankingClick}>
           <div className="inline-flex items-center justify-start mr-[24px]">

--- a/src/pages/HomePage/component/LiveDiscussion.tsx
+++ b/src/pages/HomePage/component/LiveDiscussion.tsx
@@ -37,9 +37,9 @@ const discussions: Discussion[] = [
 ];
 
 
-const formatNumber = (num: number | null): string => {
-  return num !== null ? new Intl.NumberFormat().format(num) : '0';
-};
+// const formatNumber = (num: number | null): string => {
+//   return num !== null ? new Intl.NumberFormat().format(num) : '0';
+// };
 
 
 const LiveDiscussion: React.FC = () => {
@@ -54,8 +54,8 @@ const LiveDiscussion: React.FC = () => {
             key={index}
             title={discussion.title}
             image={discussion.image}
-            hits={formatNumber(discussion.hits)}
-            comments={formatNumber(discussion.comments)}
+            hits={discussion.hits}
+            comments={discussion.comments}
             link={discussion.link}
             className="w-[164px] h-[100%] flex-shrink-0"
           />

--- a/src/pages/HomePage/component/LiveDiscussion.tsx
+++ b/src/pages/HomePage/component/LiveDiscussion.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import LiveDiscussion1 from '@images/LiveDiscussion/LiveDiscussion1.png';
-import LiveDiscussion2 from '@images/LiveDiscussion/LiveDiscussion2.png';
-import LiveDiscussion3 from '@images/LiveDiscussion/LiveDiscussion3.png';
+// import LiveDiscussion1 from '@images/LiveDiscussion/LiveDiscussion1.png';
+// import LiveDiscussion2 from '@images/LiveDiscussion/LiveDiscussion2.png';
+// import LiveDiscussion3 from '@images/LiveDiscussion/LiveDiscussion3.png';
+import PurpleBox from '@images/ico_purple_box.svg';
 import DiscussionCard from '@components/DiscussionCard';
 
 interface Discussion {
@@ -14,21 +15,21 @@ interface Discussion {
 
 const discussions: Discussion[] = [
   {
-    image: LiveDiscussion1,
+    image: PurpleBox,
     hits: 120,
     comments: 123,
     title: "김현주 열애설 어떻게 생각함?",
     link: "/Post1",
   },
   {
-    image: LiveDiscussion2,
+    image: PurpleBox,
     hits: 990,
     comments: 45,
     title: "김현주가 아깝다 vs 차은우가 아깝다",
     link: "/Post2",
   },
   {
-    image: LiveDiscussion3,
+    image: PurpleBox,
     hits: 990,
     comments: 45,
     title: "김현주가 아깝다 vs 차은우가 아깝다",

--- a/src/pages/HomePage/component/SearchBar.tsx
+++ b/src/pages/HomePage/component/SearchBar.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ico_search from "@images/ico_search.svg";
+
+interface SearchBarProps {
+  onClick: () => void;
+  placeholder: string;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({ onClick, placeholder }) => {
+  return (
+    <div 
+      className="w-[342px] h-[40px] flex items-center rounded-full bg-white cursor-pointer pl-4 pr-4" 
+      onClick={onClick}
+    >
+      <div className="flex justify-between items-center w-full">
+        <span className="text-gray2 font-pretendard font-normal text-[16px]">{placeholder}</span>
+        <img src={ico_search} alt="Search Icon" className="w-5 h-5" />
+      </div>
+    </div>
+  );
+}
+
+export default SearchBar;

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import SearchBar from '../../components/SearchBar';
 import RecentSearches from './components/RecentSearches';
 import PopularSearches from './components/PopularSearches';
@@ -55,26 +55,8 @@ const discussions = [
   },
 ];
 
-//여기!!!가 get한 검색 결과 dummy data
-// const initialSearchResults = [
-  // { title: '김현주 열애설', sources: ['나무위키 1등', '트위터 1등'] },
-  // { title: '김현주', sources: ['나무위키 2등', '네이버 1등'] },
-  // { title: '김윤서 차은우', sources: ['네이버 2등', '트위터 2등'] },
-  // { title: '김현주 결혼', sources: ['줌 1등'] },
-  // { title: '김윤서 결혼' },
-  // { title: '김현주 결혼', sources: ['나무위키 1등', '나무위키 1등'] },
-  // { title: '김윤서 결혼', sources: ['줌 5등', '나무위키 5등'] },
-
-// ];
-
-
-
 const SearchPage: React.FC = () => {
-  const [tags, setTags] = useState([
-    '김현주',
-    '김현주 열애설',
-    '김현주 남친',
-  ]);
+  const [tags, setTags] = useState<string[]>([]);
 
   const [isSearchActive, setIsSearchActive] = useState(false);
 
@@ -82,12 +64,21 @@ const SearchPage: React.FC = () => {
 
   const [noResults, setNoResults] = useState(false);
 
+  useEffect(() => {
+    const storedTags = JSON.parse(localStorage.getItem('recentSearches') || '[]');
+    setTags(storedTags);
+  }, []);
+
   const removeTag = (tagToRemove: string) => {
-    setTags(tags.filter(tag => tag !== tagToRemove));
+    // setTags(tags.filter(tag => tag !== tagToRemove));
+    const updatedTags = tags.filter(tag => tag !== tagToRemove);
+    setTags(updatedTags);
+    localStorage.setItem('recentSearches', JSON.stringify(updatedTags));
   };
 
   const removeAllTags = () => {
     setTags([]);
+    localStorage.removeItem('recentSearches');
   };
 
   const totalPopularSearches = [

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -81,16 +81,16 @@ const SearchPage: React.FC = () => {
     localStorage.removeItem('recentSearches');
   };
 
-  const totalPopularSearches = [
-    '김현주',
-    '김현주 소속사',
-    '김현주 열애설',
-    '김현주 남친',
-    '김현주',
-    '김현주',
-    '김현주',
-    '김현주',
-  ];
+  // const totalPopularSearches = [
+  //   '김현주',
+  //   '김현주 소속사',
+  //   '김현주 열애설',
+  //   '김현주 남친',
+  //   '김현주',
+  //   '김현주',
+  //   '김현주',
+  //   '김현주',
+  // ];
 
   interface KeywordResult {
     keyword: string;
@@ -157,7 +157,7 @@ const SearchPage: React.FC = () => {
       {!isSearchActive && !noResults && (
         <>
           <RecentSearches tags={tags} removeTag={removeTag} removeAllTags={removeAllTags} />
-          <PopularSearches searches={totalPopularSearches} />
+          <PopularSearches />
           <RecentDiscussions discussions={discussions} />
         </>
       )}

--- a/src/pages/SearchPage/components/PopularSearches.tsx
+++ b/src/pages/SearchPage/components/PopularSearches.tsx
@@ -24,13 +24,14 @@ const PopularSearches: React.FC = () => {
     try {
       const rankingData = await getRankingInfo('total', 'real_time', '');
       const top8Searches = rankingData.slice(0, 8).map(item => item.name); // 상위 8개의 name 가져오기
-      setSearches(rearrangeSearches(top8Searches));
+      setSearches(top8Searches);
     } catch (error) {
       console.error('인기 검색어 데이터를 불러오는 중 오류 발생:', error);
       setSearches([]);
     }
   };
 
+  // maxLength 이상이면 ... 처리
   const truncateText = (text: string, maxLength: number) => {
     if (text.length > maxLength) {
       return text.slice(0, maxLength) + '...';
@@ -38,21 +39,7 @@ const PopularSearches: React.FC = () => {
     return text;
   };
 
-  const rearrangeSearches = (searches: string[]) => {
-    const halfLength = Math.ceil(searches.length / 2);
-    const firstColumn = searches.slice(0, halfLength);
-    const secondColumn = searches.slice(halfLength);
-
-    const rearranged = [];
-    for (let i = 0; i < halfLength; i++) {
-      rearranged.push(firstColumn[i]);
-      if (secondColumn[i]) {
-        rearranged.push(secondColumn[i]);
-      }
-    }
-
-    return rearranged;
-  };
+  const halfLength = Math.ceil(searches.length / 2);
 
   return (
     <div className="mt-8 mb-4">
@@ -63,14 +50,16 @@ const PopularSearches: React.FC = () => {
         </span>
       </div>
       <div className="grid grid-cols-2 gap-x-8 ml-8 mr-8">
-        {searches.map((search, index) => (
+        {searches.slice(0, halfLength).map((search, index) => (
           <div key={index} className="flex items-center mt-3">
-            <span className="font-pretendard font-bold text-[14px] text-gray3 mr-4">
-              {index + 1}
-            </span>
-            <span className="font-pretendard font-semibold text-[14px] text-black">
-              {truncateText(search, 10)}
-            </span>
+            <span className="font-pretendard font-bold text-[14px] text-gray3 mr-4">{index + 1}</span>
+            <span className="font-pretendard font-semibold text-[14px] text-black">{truncateText(search, 10)}</span>
+          </div>
+        ))}
+        {searches.slice(halfLength).map((search, index) => (
+          <div key={index + halfLength} className="flex items-center mt-3">
+            <span className="font-pretendard font-bold text-[14px] text-gray3 mr-4">{index + halfLength + 1}</span>
+            <span className="font-pretendard font-semibold text-[14px] text-black">{truncateText(search, 10)}</span>
           </div>
         ))}
       </div>

--- a/src/pages/SearchPage/components/PopularSearches.tsx
+++ b/src/pages/SearchPage/components/PopularSearches.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { getRankingInfo } from '@apis/getRankingInfo';
 
-// interface PopularSearchesProps {
-//   searches: string[];
-// }
-
 const PopularSearches: React.FC = () => {
   const [searches, setSearches] = useState<string[]>([]);
   const [currentTime, setCurrentTime] = useState('');
@@ -28,14 +24,13 @@ const PopularSearches: React.FC = () => {
     try {
       const rankingData = await getRankingInfo('total', 'real_time', '');
       const top8Searches = rankingData.slice(0, 8).map(item => item.name); // 상위 8개의 name 가져오기
-      setSearches(top8Searches);
+      setSearches(rearrangeSearches(top8Searches));
     } catch (error) {
       console.error('인기 검색어 데이터를 불러오는 중 오류 발생:', error);
       setSearches([]);
     }
   };
 
-  // maxLength 이상이면 ... 처리
   const truncateText = (text: string, maxLength: number) => {
     if (text.length > maxLength) {
       return text.slice(0, maxLength) + '...';
@@ -43,7 +38,21 @@ const PopularSearches: React.FC = () => {
     return text;
   };
 
-  const halfLength = Math.ceil(searches.length / 2);
+  const rearrangeSearches = (searches: string[]) => {
+    const halfLength = Math.ceil(searches.length / 2);
+    const firstColumn = searches.slice(0, halfLength);
+    const secondColumn = searches.slice(halfLength);
+
+    const rearranged = [];
+    for (let i = 0; i < halfLength; i++) {
+      rearranged.push(firstColumn[i]);
+      if (secondColumn[i]) {
+        rearranged.push(secondColumn[i]);
+      }
+    }
+
+    return rearranged;
+  };
 
   return (
     <div className="mt-8 mb-4">
@@ -54,16 +63,14 @@ const PopularSearches: React.FC = () => {
         </span>
       </div>
       <div className="grid grid-cols-2 gap-x-8 ml-8 mr-8">
-        {searches.slice(0, halfLength).map((search, index) => (
+        {searches.map((search, index) => (
           <div key={index} className="flex items-center mt-3">
-            <span className="font-pretendard font-bold text-[14px] text-gray3 mr-4">{index + 1}</span>
-            <span className="font-pretendard font-semibold text-[14px] text-black">{truncateText(search, 10)}</span>
-          </div>
-        ))}
-        {searches.slice(halfLength).map((search, index) => (
-          <div key={index} className="flex items-center mt-3">
-            <span className="font-pretendard font-bold text-[14px] text-gray3 mr-4">{index + halfLength + 1}</span>
-            <span className="font-pretendard font-semibold text-[14px] text-black">{truncateText(search, 10)}</span>
+            <span className="font-pretendard font-bold text-[14px] text-gray3 mr-4">
+              {index + 1}
+            </span>
+            <span className="font-pretendard font-semibold text-[14px] text-black">
+              {truncateText(search, 10)}
+            </span>
           </div>
         ))}
       </div>

--- a/src/pages/SearchPage/components/PopularSearches.tsx
+++ b/src/pages/SearchPage/components/PopularSearches.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import { getRankingInfo } from '@apis/getRankingInfo';
 
-interface PopularSearchesProps {
-  searches: string[];
-}
+// interface PopularSearchesProps {
+//   searches: string[];
+// }
 
-const PopularSearches: React.FC<PopularSearchesProps> = ({ searches }) => {
+const PopularSearches: React.FC = () => {
+  const [searches, setSearches] = useState<string[]>([]);
   const [currentTime, setCurrentTime] = useState('');
 
   const updateCurrentTime = () => {
@@ -19,7 +21,27 @@ const PopularSearches: React.FC<PopularSearchesProps> = ({ searches }) => {
 
   useEffect(() => {
     updateCurrentTime();
+    fetchPopularSearches();
   }, []);
+
+  const fetchPopularSearches = async () => {
+    try {
+      const rankingData = await getRankingInfo('total', 'real_time', '');
+      const top8Searches = rankingData.slice(0, 8).map(item => item.name); // 상위 8개의 name 가져오기
+      setSearches(top8Searches);
+    } catch (error) {
+      console.error('인기 검색어 데이터를 불러오는 중 오류 발생:', error);
+      setSearches([]);
+    }
+  };
+
+  // maxLength 이상이면 ... 처리
+  const truncateText = (text: string, maxLength: number) => {
+    if (text.length > maxLength) {
+      return text.slice(0, maxLength) + '...';
+    }
+    return text;
+  };
 
   const halfLength = Math.ceil(searches.length / 2);
 
@@ -35,13 +57,13 @@ const PopularSearches: React.FC<PopularSearchesProps> = ({ searches }) => {
         {searches.slice(0, halfLength).map((search, index) => (
           <div key={index} className="flex items-center mt-3">
             <span className="font-pretendard font-bold text-[14px] text-gray3 mr-4">{index + 1}</span>
-            <span className="font-pretendard font-semibold text-[14px] text-black">{search}</span>
+            <span className="font-pretendard font-semibold text-[14px] text-black">{truncateText(search, 10)}</span>
           </div>
         ))}
         {searches.slice(halfLength).map((search, index) => (
           <div key={index} className="flex items-center mt-3">
             <span className="font-pretendard font-bold text-[14px] text-gray3 mr-4">{index + halfLength + 1}</span>
-            <span className="font-pretendard font-semibold text-[14px] text-black">{search}</span>
+            <span className="font-pretendard font-semibold text-[14px] text-black">{truncateText(search, 10)}</span>
           </div>
         ))}
       </div>

--- a/src/pages/SearchPage/components/RecentSearches.tsx
+++ b/src/pages/SearchPage/components/RecentSearches.tsx
@@ -11,22 +11,28 @@ const RecentSearches: React.FC<RecentSearchesProps> = ({ tags, removeTag, remove
   <div className="mt-6 mb-4">
     <div className="flex justify-between items-center mb-2">
       <label className="block font-pretendard font-bold text-[14px] text-gray3 ml-8">최근 검색어</label>
-      <button 
-        onClick={removeAllTags}
-        className="text-gray2 mr-8 underline font-pretendard font-medium text-[14px]"
-      >
-        지우기
-      </button>
+      {tags.length > 0 && (
+        <button 
+          onClick={removeAllTags}
+          className="text-gray2 mr-8 underline font-pretendard font-medium text-[14px]"
+        >
+          지우기
+        </button>
+      )}
     </div>
-    <div className="flex flex-wrap gap-2 ml-8 mr-8">
-      {tags.map(tag => (
-        <div key={tag} className="flex items-center bg-gray1 font-pretendard font-normal text-[14px] text-black px-2 py-1 rounded-full">
-          <span>{tag}</span>
-          <button onClick={() => removeTag(tag)} className="ml-2">
-            <img src={ico_delete_black} alt="delete" />
-          </button>
-        </div>
-      ))}
+    <div className={`flex flex-wrap gap-2 ml-8 mr-8 ${tags.length === 0 ? 'h-[40px]' : ''}`}>
+      {tags.length > 0 ? (
+        tags.map(tag => (
+          <div key={tag} className="flex items-center bg-gray1 font-pretendard font-normal text-[14px] text-black px-2 py-1 rounded-full">
+            <span>{tag}</span>
+            <button onClick={() => removeTag(tag)} className="ml-2">
+              <img src={ico_delete_black} alt="delete" />
+            </button>
+          </div>
+        ))
+      ) : (
+        <div className="text-gray2 text-[14px] font-pretendard font-medium">최근 검색어가 없습니다.</div>
+      )}
     </div>
   </div>
 );

--- a/src/pages/SearchPage/components/RecentSearches.tsx
+++ b/src/pages/SearchPage/components/RecentSearches.tsx
@@ -33,7 +33,7 @@ const RecentSearches: React.FC<RecentSearchesProps> = ({ tags, removeTag, remove
           ))}
         </div>
       ) : (
-        <div className="flex justify-center items-center h-full text-gray2 text-[14px] font-pretendard font-medium">
+        <div className="flex justify-center items-center h-full text-gray3 text-[16px] font-pretendard font-medium">
           최근 검색어가 없어요
         </div>
       )}

--- a/src/pages/SearchPage/components/RecentSearches.tsx
+++ b/src/pages/SearchPage/components/RecentSearches.tsx
@@ -20,18 +20,22 @@ const RecentSearches: React.FC<RecentSearchesProps> = ({ tags, removeTag, remove
         </button>
       )}
     </div>
-    <div className={`flex flex-wrap gap-2 ml-8 mr-8 ${tags.length === 0 ? 'h-[40px]' : ''}`}>
+    <div className="ml-8 mr-8" style={{ height: '30px' }}>
       {tags.length > 0 ? (
-        tags.map(tag => (
-          <div key={tag} className="flex items-center bg-gray1 font-pretendard font-normal text-[14px] text-black px-2 py-1 rounded-full">
-            <span>{tag}</span>
-            <button onClick={() => removeTag(tag)} className="ml-2">
-              <img src={ico_delete_black} alt="delete" />
-            </button>
-          </div>
-        ))
+        <div className="flex flex-wrap gap-2 h-full py-[2px]">
+          {tags.map(tag => (
+            <div key={tag} className="flex items-center bg-gray1 font-pretendard font-normal text-[14px] text-black px-2 py-1 rounded-full">
+              <span>{tag}</span>
+              <button onClick={() => removeTag(tag)} className="ml-2">
+                <img src={ico_delete_black} alt="delete" />
+              </button>
+            </div>
+          ))}
+        </div>
       ) : (
-        <div className="text-gray2 text-[14px] font-pretendard font-medium">최근 검색어가 없습니다.</div>
+        <div className="flex justify-center items-center h-full text-gray2 text-[14px] font-pretendard font-medium">
+          최근 검색어가 없어요
+        </div>
       )}
     </div>
   </div>

--- a/src/store/trendStore.ts
+++ b/src/store/trendStore.ts
@@ -1,40 +1,3 @@
-//실시간 데이터 연동: zustand, axios
-// import create from 'zustand';
-// import axios from 'axios';
-
-// interface Trend {
-//   rank: number;
-//   name: string;
-//   tags: string[];
-// }
-
-// interface TrendState {
-//   menuType: 'realTime' | 'daily' | 'weekly';
-//   date: string;
-//   trends: Trend[];
-//   setMenuType: (type: 'realTime' | 'daily' | 'weekly') => void;
-//   setDate: (date: string) => void;
-//   fetchTrends: () => void;
-// }
-
-// export const useTrendStore = create<TrendState>((set, get) => ({
-//   menuType: 'realTime',
-//   date: new Date().toISOString().split('T')[0],
-//   trends: [],
-//   setMenuType: (type) => set({ menuType: type }),
-//   setDate: (date) => set({ date }),
-//   fetchTrends: async () => {
-//     const { menuType, date } = get();
-//     try {
-//       const response = await axios.get(`/api/trends?type=${menuType}&date=${date}`);
-//       set({ trends: response.data });
-//     } catch (error) {
-//       console.error('Error fetching trends:', error);
-//     }
-//   },
-// }));
-
-//1차 발표를 위해 더미 데이터 생성
 import create from 'zustand';
 import { getRankingInfo } from '@apis/getRankingInfo';
 
@@ -54,19 +17,6 @@ interface TrendState {
   setDate: (date: string) => void;
   fetchTrends: () => void;
 }
-
-// const fakeTrends: Trend[] = [
-//   { rank: 1, name: '김현주', tags: ['나무위키 1등', '트위터 1등', '네이버 2등'] },
-//   { rank: 2, name: '열애설', tags: ['네이버 1등', '다음카페 1등', '트위터 2등'] },
-//   { rank: 3, name: '결혼', tags: ['인스티즈 1등', '네이트판 1등', '나무위키 2등'] },
-//   { rank: 4, name: '소속사', tags: ['인스티즈 2등', '네이버 3등'] },
-//   { rank: 5, name: '야구', tags: ['디시인사이드 1등', '트위터 3등'] },
-//   { rank: 6, name: '뉴진스', tags: ['나무위키 1등', '트위터 1등'] },
-//   { rank: 7, name: '야구선수', tags: ['나무위키 1등', '트위터 1등'] },
-//   { rank: 8, name: '롯데자이언츠', tags: ['나무위키 1등', '트위터 1등'] },
-//   { rank: 9, name: '퇴근', tags: ['나무위키 1등', '트위터 1등'] },
-//   { rank: 10, name: '아이폰', tags: ['나무위키 1등', '트위터 1등'] },
-// ];
 
 export const useTrendStore = create<TrendState>((set, get) => ({
   menuType: 'realTime',


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요. ( main ❌ / develop ⭕ )
- PR의 제목에도 관련 이슈 번호를 포함시켜 주세요.
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #86

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] 검색 페이지 : 최근 검색어 empty view 구현
- [x] 검색 페이지 : 최근 검색어 로컬 스토리지로 불러오기 구현
- [x] 검색 페이지 : 통합 인기 검색어 순위 API 연결 (랭킹 조회의 실시간 total 중 상위 8개)
- [x] 검색 페이지 : 키워드 검색 GET API 연결 구현 수정 - 복구 후 확인
- [x] 홈 : 통합 랭킹 시간 수정
- [x] 홈 : 커뮤니티 랭킹 시간 수정
- [x] 홈 : 커뮤니티 랭킹에서 랭킹보기 라우팅 연결
- [x] + 서버 측의 검색 기능 수정됨 : 원래는 검색 내용으로 시작하는 키워드들만 떴다면, 이제는 포함만 돼도 뜸


## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁



## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
