### PR TITLE
[FEAT/#100] 검색 페이지 최근 본 토론 GET API 연결

### DIFF
--- a/src/apis/getRecentDiscussion.ts
+++ b/src/apis/getRecentDiscussion.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+export const getRecentDiscussion = async () => {
+  try {
+    const token = localStorage.getItem('accessToken');
+
+    const response = await axios.get(`debate/recent`, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
+    });
+    
+    return response.data.result;
+  } catch (error) {
+    console.error('검색페이지의 최근 본 토론 불러오는 중 오류 발생:', error);
+    throw error;
+  }
+};

--- a/src/components/DiscussionCard.tsx
+++ b/src/components/DiscussionCard.tsx
@@ -20,7 +20,7 @@ const DiscussionCard: React.FC<DiscussionCardProps> = ({ image, hits, comments, 
   <div className={`font-pretendard ${className}`}>
     {image === PurpleBox ? (
       <div 
-        className="w-[164px] h-[200px] bg-purple-500 rounded-2xl mb-2 flex items-center justify-center text-white text-center p-2"
+        className="w-[164px] h-[200px] bg-point500 rounded-2xl mb-2 flex items-center justify-center text-white text-center p-2"
         style={{ backgroundImage: `url(${PurpleBox})`, backgroundSize: 'cover' }}
       >
         <span className="text-[14px] font-pretendard font-semibold px-[15px] leading-6">{title}</span>

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -5,56 +5,8 @@ import PopularSearches from './components/PopularSearches';
 import RecentDiscussions from './components/RecentDiscussions';
 import SearchResultItem from './components/SearchResultItem';
 import ErrorPage from './components/405ErrorPage';
-// import LiveDiscussion1 from '../../assets/images/LiveDiscussion/LiveDiscussion1.png';
-// import LiveDiscussion2 from '../../assets/images/LiveDiscussion/LiveDiscussion2.png';
-// import LiveDiscussion3 from '../../assets/images/LiveDiscussion/LiveDiscussion3.png';
-import PurpleBox from '../../assets/images/ico_purple_box.svg';
+// import PurpleBox from '../../assets/images/ico_purple_box.svg';
 import { getKeyword } from '@apis/getKeyword';
-
-const discussions = [
-  {
-    image: PurpleBox,
-    hits: 1210,
-    comments: 2830,
-    title: "김현주 열애설 어떻게 생각함?",
-    link: "/Post1",
-  },
-  {
-    image: PurpleBox,
-    hits: 990,
-    comments: null,
-    title: "김현주가 아깝다 vs 차은우가 아깝다",
-    link: "/Post2",
-  },
-  {
-    image: PurpleBox,
-    hits: 32,
-    comments: 48302,
-    title: "현주씨 오늘 저녁 뭐 드셨어요",
-    link: "/Post3",
-  },
-  {
-    image: PurpleBox,
-    hits: 93021,
-    comments: 123,
-    title: "뉴진스! 뉴진스!",
-    link: "/Post4",
-  },
-  {
-    image: PurpleBox,
-    hits: null,
-    comments: 594,
-    title: "현주씨 오늘 저녁 뭐 드셨어요",
-    link: "/Post5",
-  },
-  {
-    image: PurpleBox,
-    hits: 145,
-    comments: 3048,
-    title: "김현주 열애설 어떻게 생각함?",
-    link: "/Post6",
-  },
-];
 
 const SearchPage: React.FC = () => {
   const [tags, setTags] = useState<string[]>([]);

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -5,49 +5,50 @@ import PopularSearches from './components/PopularSearches';
 import RecentDiscussions from './components/RecentDiscussions';
 import SearchResultItem from './components/SearchResultItem';
 import ErrorPage from './components/405ErrorPage';
-import LiveDiscussion1 from '../../assets/images/LiveDiscussion/LiveDiscussion1.png';
-import LiveDiscussion2 from '../../assets/images/LiveDiscussion/LiveDiscussion2.png';
-import LiveDiscussion3 from '../../assets/images/LiveDiscussion/LiveDiscussion3.png';
+// import LiveDiscussion1 from '../../assets/images/LiveDiscussion/LiveDiscussion1.png';
+// import LiveDiscussion2 from '../../assets/images/LiveDiscussion/LiveDiscussion2.png';
+// import LiveDiscussion3 from '../../assets/images/LiveDiscussion/LiveDiscussion3.png';
+import PurpleBox from '../../assets/images/ico_purple_box.svg';
 import { getKeyword } from '@apis/getKeyword';
 
 const discussions = [
   {
-    image: LiveDiscussion1,
+    image: PurpleBox,
     hits: 1210,
     comments: 2830,
     title: "김현주 열애설 어떻게 생각함?",
     link: "/Post1",
   },
   {
-    image: LiveDiscussion2,
+    image: PurpleBox,
     hits: 990,
     comments: null,
     title: "김현주가 아깝다 vs 차은우가 아깝다",
     link: "/Post2",
   },
   {
-    image: LiveDiscussion3,
+    image: PurpleBox,
     hits: 32,
     comments: 48302,
     title: "현주씨 오늘 저녁 뭐 드셨어요",
     link: "/Post3",
   },
   {
-    image: LiveDiscussion1,
+    image: PurpleBox,
     hits: 93021,
     comments: 123,
     title: "뉴진스! 뉴진스!",
     link: "/Post4",
   },
   {
-    image: LiveDiscussion2,
+    image: PurpleBox,
     hits: null,
     comments: 594,
     title: "현주씨 오늘 저녁 뭐 드셨어요",
     link: "/Post5",
   },
   {
-    image: LiveDiscussion3,
+    image: PurpleBox,
     hits: 145,
     comments: 3048,
     title: "김현주 열애설 어떻게 생각함?",
@@ -147,7 +148,7 @@ const SearchPage: React.FC = () => {
         <>
           <RecentSearches tags={tags} removeTag={removeTag} removeAllTags={removeAllTags} />
           <PopularSearches />
-          <RecentDiscussions discussions={discussions} />
+          <RecentDiscussions />
         </>
       )}
 

--- a/src/pages/SearchPage/components/RecentDiscussions.tsx
+++ b/src/pages/SearchPage/components/RecentDiscussions.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import DiscussionCard from '../../../components/DiscussionCard';
+import { getRecentDiscussion } from '@apis/getRecentDiscussion';
+import PurpleBox from '@images/ico_purple_box.svg';
+
 interface DiscussionCardProps {
   image: string;
   hits: number;
@@ -8,17 +11,58 @@ interface DiscussionCardProps {
   link: string;
 }
 
-const RecentDiscussions: React.FC<{ discussions: DiscussionCardProps[] }> = ({ discussions }) => (
-  <div className="mt-10 mb-4">
-    <div className="flex justify-between items-center">
-      <label className="block font-pretendard font-bold text-[14px] text-gray3 ml-8">최근 본 토론</label>
+interface Response {
+  title: string;
+  debateId: number;
+  mediaUrl?: string;
+  hit: number;
+  comment: number;
+}
+
+const RecentDiscussions: React.FC = () => {
+  const [discussions, setDiscussions] = useState<DiscussionCardProps[]>([]);
+
+  useEffect(() => {
+    const fetchDiscussions = async () => {
+      try {
+        const result: Response[] = await getRecentDiscussion();
+        const formattedDiscussions: DiscussionCardProps[] = result.map((item) => ({
+          title: item.title,
+          hits: item.hit,
+          image: item.mediaUrl || PurpleBox,
+          comments: item.comment,
+          link: `/post/${item.debateId}`, // 링크를 debateId로 초기화
+        }));
+        setDiscussions(formattedDiscussions);
+        console.log('최근 본 토론 데이터 가져오기 성공', result);
+      } catch (error) {
+        console.error('최근 본 토론 데이터를 가져오는 중 오류 발생:', error);
+      }
+    };
+
+    fetchDiscussions();
+  }, []);
+
+  return (
+    <div className="mt-10 mb-4">
+      <div className="flex justify-between items-center">
+        <label className="block font-pretendard font-bold text-[14px] text-gray3 ml-8">최근 본 토론</label>
+      </div>
+      <div className="grid grid-cols-2 gap-4 mt-3 ml-8 mr-8">
+        {discussions.map((discussion, index) => (
+          <DiscussionCard 
+            key={index}
+            title={discussion.title}
+            image={discussion.image}
+            hits={discussion.hits}
+            comments={discussion.comments}
+            link={discussion.link}
+            className="w-[164px] h-[100%] flex-shrink-0"
+          />
+        ))}
+      </div>
     </div>
-    <div className="grid grid-cols-2 gap-4 mt-3 ml-8 mr-8">
-      {discussions.map((discussion, index) => (
-        <DiscussionCard key={index} {...discussion} />
-      ))}
-    </div>
-  </div>
-);
+  );
+};
 
 export default RecentDiscussions;


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요. ( main ❌ / develop ⭕ )
- PR의 제목에도 관련 이슈 번호를 포함시켜 주세요.
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #100

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] 검색 페이지 최근 본 토론 GET API 연결
- [x] DiscussionCard empty view background color 수정

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<img width="292" alt="화면 캡처 2024-08-19 222851" src="https://github.com/user-attachments/assets/2dd3e7f6-9f4f-4187-8a2a-96e380d24b35">


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
최근 본 토론 GET API까지 하여 검색 페이지 api 모두 연결 완료하였습니다. 
홈, 검색 모두 완료입니다.
이제 검색 후 관련자료, 키워드 관련 토론 조회 api,
토론 쪽 api들 남았네요
화이팅 !!!